### PR TITLE
TIC_80-Coding-Train-Logo

### DIFF
--- a/ports/TIC_80-Coding-Train-Logo
+++ b/ports/TIC_80-Coding-Train-Logo
@@ -1,0 +1,36 @@
+-- title: Coding Train logo for Hacktober
+-- author: Alesk 69
+-- script:  lua
+-- link: https://tic80.com/play?cart=3581
+function TIC()
+
+	cls(12)
+	
+	line (16, 27, 16, 21, 1);
+  line (16, 21, 14, 21, 1);
+  line (16, 21, 14, 21, 1);
+  line (14, 21, 14, 17, 1);
+  line (14, 17, 31, 17, 1);
+  line (31, 17, 31, 24, 1);
+ --Next part 
+  line(35, 24, 33, 17, 11);
+  line(34, 17, 42, 17, 11);
+  line(44, 17, 42, 24, 11);
+ --Next part 
+  line(49, 41, 45, 36, 2);
+  line(45, 36, 47, 30, 2);
+  line(47, 30, 45, 24, 2);
+  --
+  circb (21, 37, (4.5 * 2), 1); 
+ --
+  circb (34, 42, (2 * 2), 11);
+ --
+ 	circb (42, 42, (2 * 2), 11);
+ -- 
+ 	line(41, 27, 41, 33, 3);
+  line(38, 27, 38, 33, 3);
+  line(35, 27, 35, 33, 3);
+ --
+  line(42, 36, 34, 36, 3);  
+	
+end


### PR DESCRIPTION
A version of the Coding Train logo in the Tic 80 fantasy computer.

## Port

- **Coding Train logo for Hacktober in the Tic-80**
- **Alesk 69** 
- **[Link to code / output](https://tic80.com/play?cart=3581)**:

<!-- ![coding-train-tic-80](https://github.com/Alesk1969/Coding-Train-Logo/assets/60976821/9f3fc506-5741-4df5-a047-8d510e6ade94) -->
